### PR TITLE
Set access to public to fix publish error

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
   },
   "homepage": "https://github.com/Expensify/react-native-wallet#readme",
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.25.3",


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

<!-- Explanation of the change or anything fishy that is going on -->

Fixes error https://github.com/Expensify/react-native-wallet/actions/runs/15784521784/job/44501438204

```
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access
npm error code EUSAGE
npm error Can't generate provenance for new or private package, you must set `access` to public.
```

Scoped packages (starting with @) default to private access, this will fix it.

### Manual Tests

Merge this PR, make sure it publishes ⚡ 

