### PR TITLE
fix: update Apple Pay entitlements email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,19 @@ With all the required data, submit the form and wait for Google's response. Afte
 
 ### Step 1: Apply for appropriate entitlements
 
-To enable In-App Provisioning in your app, you must request activation of the appropriate Apple Pay entitlements for your developer Team ID. Enterprise Team IDs are not supported. This entitlement is not available by default in our panel; you will need to request it. Send an email to apple-pay-provisioning@apple.com with your app name, Team ID, and Adam ID.
+To enable In-App Provisioning in your app, you must request activation of the appropriate Apple Pay entitlements for your developer Team ID. Enterprise Team IDs are not supported. This entitlement is not available by default in our panel; you will need to request it. Send an email to `iap_entitlements@apple.com` with the following format:
+
+**Subject:** `Apple Pay Entitlements and Allow List Request - [Issuer Name] - [Country Code]`
+
+**Body:**
+- Issuer Name
+- Country [Country Code]
+- Team ID
+- Adam ID
+- App Name
+
+> [!NOTE]
+> Only a production Team ID and Adam ID can receive the entitlement. Test Team IDs don't qualify.
 
 Once Apple verifies your identity, you should get documentation named `Getting Started with Apple Pay In-App Provisioning, Verification & Security`. In this confidential document you will find all the relevant information about:
 - Prerequisites for your project

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ With all the required data, submit the form and wait for Google's response. Afte
 
 To enable In-App Provisioning in your app, you must request activation of the appropriate Apple Pay entitlements for your developer Team ID. Enterprise Team IDs are not supported. This entitlement is not available by default in our panel; you will need to request it.
 
-Submit your request through the [In-App Provisioning Submission Form](https://developer.apple.com/contact/request/apple-pay-in-app-provisioning/). Alternatively, you can email `iap_entitlements@apple.com` with the following format:
+Submit your request through the [In-App Provisioning Submission Form](https://developer.apple.com/contact/request/apple-pay-in-app-provisioning/). Only Account Holders can access this form — if you are unable to access it, coordinate with the Account Holder of your team. Alternatively, you can email `iap_entitlements@apple.com` with the following format:
 
 **Subject:** `Apple Pay Entitlements and Allow List Request - [Issuer Name] - [Country Code]`
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ With all the required data, submit the form and wait for Google's response. Afte
 
 ### Step 1: Apply for appropriate entitlements
 
-To enable In-App Provisioning in your app, you must request activation of the appropriate Apple Pay entitlements for your developer Team ID. Enterprise Team IDs are not supported. This entitlement is not available by default in our panel; you will need to request it. Send an email to `iap_entitlements@apple.com` with the following format:
+To enable In-App Provisioning in your app, you must request activation of the appropriate Apple Pay entitlements for your developer Team ID. Enterprise Team IDs are not supported. This entitlement is not available by default in our panel; you will need to request it.
+
+Submit your request through the [In-App Provisioning Submission Form](https://developer.apple.com/contact/request/apple-pay-in-app-provisioning/). Alternatively, you can email `iap_entitlements@apple.com` with the following format:
 
 **Subject:** `Apple Pay Entitlements and Allow List Request - [Issuer Name] - [Country Code]`
 


### PR DESCRIPTION
## Summary
- Updated the Apple Pay entitlements email from `apple-pay-provisioning@apple.com` to `iap_entitlements@apple.com`
- Added the required email format (subject line and body content) per Apple's documentation

## Context
The previous email address bounces with "the address couldn't be found, or is unable to receive mail."

The correct email and format is documented on Apple's official In-App Provisioning page:
https://applepaydemo.apple.com/in-app-provisioning#1

## Test plan
- [x] Verified email format against Apple's official documentation

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)