### PR TITLE
avoid double-settling Promise in checkWalletAvailability

### DIFF
--- a/android/src/main/java/com/expensify/wallet/WalletModule.kt
+++ b/android/src/main/java/com/expensify/wallet/WalletModule.kt
@@ -107,14 +107,7 @@ class WalletModule internal constructor(context: ReactApplicationContext) :
   @ReactMethod
   override fun checkWalletAvailability(promise: Promise) {
     tapAndPayClient.environment.addOnCompleteListener { task ->
-      if (task.isSuccessful) {
-        promise.resolve(true)
-      } else {
-        promise.resolve(false)
-      }
-    }.addOnFailureListener { e ->
-      promise.reject(E_OPERATION_FAILED, "Checking Wallet availability failed: ${e.localizedMessage}")
-    }
+      promise.resolve(task.isSuccessful)
   }
 
   @ReactMethod


### PR DESCRIPTION
TapAndPay environment Task invokes onComplete for both success and failure; our handler always resolve()d there, then also reject()d in addOnFailureListener. On failures this meant the same React Native Promise could be settled twice (resolve then reject), causing “Promise already settled” warnings and flaky JS-side behavior. Handle the result in a single callback and resolve once with task.isSuccessful.