### PR TITLE
Fix installing expo plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@expensify/react-native-wallet",
       "version": "0.1.20",
-      "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
         "apps/common-app",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,10 @@
     "lint": "eslint . --ext .js,.ts,.tsx",
     "lint:root": "eslint . --ext .js,.ts,.tsx --ignore-pattern '/plugins/**/*' --ignore-pattern '/apps/**/*'",
     "clean": "del-cli android/build apps/basic-example/android/build apps/basic-example/android/app/build apps/basic-example/ios/build apps/expo-example/android/build apps/expo-example/ios/build lib plugins/build",
-    "prepare": "bob build",
+    "prepare": "bob build && npm run build:plugins",
     "build:watch": "nodemon --watch src --ext .ts,.tsx,.css --exec \"rm -f .build_complete && npm run prepare && npm pack && touch .build_complete\"",
     "release": "release-it",
-    "build:plugins": "cd plugins && npx tsc",
-    "postinstall": "npm run build:plugins"
+    "build:plugins": "cd plugins && npx tsc"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Currently, the expo-plugin must be installed when the library is installed, which is not ideal as we want our library to work without Expo as well. 
I have moved the plugin installation to the `prepare` command, so that they are built when the library is published, not during every install.

<!-- Explanation of the change or anything fishy that is going on -->

### Related Issues

<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->

GH_LINK

### Manual Tests

<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
Installing library in apps with and without expo.

### Linked PRs

<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
