### PR TITLE
fix(android): update reject overrides to use nullable code param for …

### DIFF
--- a/android/src/main/java/com/expensify/wallet/Utils.kt
+++ b/android/src/main/java/com/expensify/wallet/Utils.kt
@@ -56,21 +56,21 @@ object Utils {
               )
             }
 
-            override fun reject(code: String, userInfo: WritableMap) {
+            override fun reject(code: String?, userInfo: WritableMap) {
               val errorMessage = "Error: $code\nUserInfo: $userInfo"
               continuation.resumeWithException(
                 Exception(errorMessage)
               )
             }
 
-            override fun reject(code: String, message: String?) {
+            override fun reject(code: String?, message: String?) {
               val errorMessage = "Error: $code\nMessage: ${message ?: "No message provided"}"
               continuation.resumeWithException(
                 Exception(errorMessage)
               )
             }
 
-            override fun reject(code: String, message: String?, userInfo: WritableMap) {
+            override fun reject(code: String?, message: String?, userInfo: WritableMap) {
               val errorMessage =
                 "Error: $code\nMessage: ${message ?: "No message provided"}\nUserInfo: $userInfo"
               continuation.resumeWithException(
@@ -78,21 +78,21 @@ object Utils {
               )
             }
 
-            override fun reject(code: String, message: String?, throwable: Throwable?) {
+            override fun reject(code: String?, message: String?, throwable: Throwable?) {
               val errorMessage = "Error: $code\nMessage: ${message ?: "No message provided"}"
               continuation.resumeWithException(
                 throwable ?: Exception(errorMessage)
               )
             }
 
-            override fun reject(code: String, throwable: Throwable?) {
+            override fun reject(code: String?, throwable: Throwable?) {
               val errorMessage = "Error: $code"
               continuation.resumeWithException(
                 throwable ?: Exception(errorMessage)
               )
             }
 
-            override fun reject(code: String, throwable: Throwable?, userInfo: WritableMap) {
+            override fun reject(code: String?, throwable: Throwable?, userInfo: WritableMap) {
               val errorMessage = "Error: $code\nUserInfo: $userInfo"
               continuation.resumeWithException(
                 throwable ?: Exception(errorMessage)

--- a/android/src/main/java/com/expensify/wallet/Utils.kt
+++ b/android/src/main/java/com/expensify/wallet/Utils.kt
@@ -57,14 +57,14 @@ object Utils {
             }
 
             override fun reject(code: String?, userInfo: WritableMap) {
-              val errorMessage = "Error: $code\nUserInfo: $userInfo"
+              val errorMessage = "Error: ${code ?: "Unknown code"}\nUserInfo: $userInfo"
               continuation.resumeWithException(
                 Exception(errorMessage)
               )
             }
 
             override fun reject(code: String?, message: String?) {
-              val errorMessage = "Error: $code\nMessage: ${message ?: "No message provided"}"
+              val errorMessage = "Error: ${code ?: "Unknown code"}\nMessage: ${message ?: "No message provided"}"
               continuation.resumeWithException(
                 Exception(errorMessage)
               )
@@ -72,28 +72,28 @@ object Utils {
 
             override fun reject(code: String?, message: String?, userInfo: WritableMap) {
               val errorMessage =
-                "Error: $code\nMessage: ${message ?: "No message provided"}\nUserInfo: $userInfo"
+                "Error: ${code ?: "Unknown code"}\nMessage: ${message ?: "No message provided"}\nUserInfo: $userInfo"
               continuation.resumeWithException(
                 Exception(errorMessage)
               )
             }
 
             override fun reject(code: String?, message: String?, throwable: Throwable?) {
-              val errorMessage = "Error: $code\nMessage: ${message ?: "No message provided"}"
+              val errorMessage = "Error: ${code ?: "Unknown code"}\nMessage: ${message ?: "No message provided"}"
               continuation.resumeWithException(
                 throwable ?: Exception(errorMessage)
               )
             }
 
             override fun reject(code: String?, throwable: Throwable?) {
-              val errorMessage = "Error: $code"
+              val errorMessage = "Error: ${code ?: "Unknown code"}"
               continuation.resumeWithException(
                 throwable ?: Exception(errorMessage)
               )
             }
 
             override fun reject(code: String?, throwable: Throwable?, userInfo: WritableMap) {
-              val errorMessage = "Error: $code\nUserInfo: $userInfo"
+              val errorMessage = "Error: ${code ?: "Unknown code"}\nUserInfo: $userInfo"
               continuation.resumeWithException(
                 throwable ?: Exception(errorMessage)
               )


### PR DESCRIPTION
# Details
RN 0.85 updated the Promise interface in react-native so that the code parameter in all reject overrides is now String? (nullable) instead of String. This change updates Utils.kt to match the new interface signatures, fixing a compilation error when building with RN 0.85.3.

# Related Issues
https://github.com/Expensify/App/issues/91629

# Manual Tests
Build the Android app with RN 0.85.3 - previously failed to compile due to signature mismatch, now builds successfully.

# Linked PRs
https://github.com/Expensify/App/pull/92484
https://github.com/Expensify/Mobile-Expensify/pull/13959
