### PR TITLE
fix(ios): resolve Swift header with __has_include

### DIFF
--- a/ios/RNWallet.mm
+++ b/ios/RNWallet.mm
@@ -1,7 +1,7 @@
 #import <PassKit/PassKit.h>
 #import "RNWallet.h"
 
-#if RNWallet_USE_FRAMEWORKS
+#if __has_include(<react_native_wallet/react_native_wallet-Swift.h>)
 #import <react_native_wallet/react_native_wallet-Swift.h>
 #else
 #import <react_native_wallet-Swift.h>

--- a/react-native-wallet.podspec
+++ b/react-native-wallet.podspec
@@ -2,17 +2,6 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-$RNWallet = Object.new
-
-def $RNWallet._add_compiler_flags(sp, extra_flags)
-  exisiting_flags = sp.attributes_hash["compiler_flags"]
-  if exisiting_flags.present?
-    sp.compiler_flags = exisiting_flags + " #{extra_flags}"
-  else
-    sp.compiler_flags = extra_flags
-  end
-end
-
 Pod::Spec.new do |s|
   s.name         = "react-native-wallet"
   s.version      = package["version"]
@@ -29,8 +18,4 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
 
   install_modules_dependencies(s);
-  
-  if ENV['USE_FRAMEWORKS']
-    $RNWallet._add_compiler_flags(s, "-DRNWallet_USE_FRAMEWORKS=1")
-  end
 end


### PR DESCRIPTION
### Details

When `USE_FRAMEWORKS` is set, the app assumes that the Swift headers will be located at `react_native_wallet/react_native_wallet-Swift.h`

In my application, when using Expo v57 and setting `useFrameworks: "static"` in `expo-build-properties`, Expo disables USE_FRAMEWORKS for this pod

```
[Expo] Disabling USE_FRAMEWORKS for 94 pods (...react-native-wallet)
```

This isn't reflected in the RNWallet_USE_FRAMEWORKS flag, and so the build fails, as it is looking in the wrong place for the header file:

```
node_modules/@expensify/react-native-wallet/ios/RNWallet.mm:5:9: fatal error:
  'react_native_wallet/react_native_wallet-Swift.h' file not found
** BUILD FAILED **
```

Instead of trying to work out if USE_FRAMEWORKS was set for this pod, we can just use __has_include to check if the header is in the expected location, defaulting back to the non-framework location. This is e.g how Expo themselves handle this situation:

https://github.com/expo/expo/blob/d33a420e1b9046486240fc46d2392e5797318917/packages/expo/ios/Swift.h#L9

### Manual Tests

I've confirmed that the library builds successfully with this change against my application.

